### PR TITLE
Increase indentation from 2 to 4 spaces in markdown output

### DIFF
--- a/bin/todoist-to-markdown
+++ b/bin/todoist-to-markdown
@@ -264,10 +264,10 @@ def print_tasks_markdown(tasks, token, indent_level=0, file=None, output_root=""
     if file is None:
         file = sys.stdout
 
-    i0 = "  " * indent_level
-    i1 = "  " * (indent_level + 1)
-    i2 = "  " * (indent_level + 2)
-    i3 = "  " * (indent_level + 3)
+    i0 = "    " * indent_level
+    i1 = "    " * (indent_level + 1)
+    i2 = "    " * (indent_level + 2)
+    i3 = "    " * (indent_level + 3)
 
     for task in tasks:
         content = task['content'].replace('\n', ' ').rstrip()
@@ -292,11 +292,11 @@ def print_tasks_markdown(tasks, token, indent_level=0, file=None, output_root=""
                         lines = comment_content.split('\n')
                         print(f"{i2}- > {lines[0]}".rstrip(), file=file)
                         for line in lines[1:]:
-                            print(f"{i2}  > {line}".rstrip(), file=file)
+                            print(f"{i2}    > {line}".rstrip(), file=file)
                         attachment = comment.get('file_attachment')
                         if attachment:
                             attachment_url = format_attachment_url(attachment, token, output_root, current_dir)
-                            print(f"{i2}  {attachment_url}", file=file)
+                            print(f"{i2}    {attachment_url}", file=file)
 
         if task['children']:
             print(f"{i1}- Sub-tasks:", file=file)


### PR DESCRIPTION
## Summary
Updated the indentation spacing in the markdown output generation to use 4 spaces instead of 2 spaces per indentation level, improving readability of nested content.

## Key Changes
- Changed base indentation unit from 2 spaces (`"  "`) to 4 spaces (`"    "`) for all indentation levels (i0, i1, i2, i3)
- Updated continuation lines for multi-line comments to use 4-space indentation
- Updated attachment URL indentation to use 4-space indentation

## Implementation Details
The change affects the `print_tasks_markdown()` function where indentation strings are constructed. All indentation variables now use 4-space increments instead of 2-space increments, ensuring consistent and deeper visual hierarchy in the generated markdown output for tasks, subtasks, comments, and attachments.

https://claude.ai/code/session_019RG2RLTzpkEeM71qrWGQmg